### PR TITLE
Introducing `CodableBridge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,144 @@
-# Swift `SerializationTools` #
+[![Tested on GitHub Actions](https://github.com/RougeWare/swift-SerializationTools/actions/workflows/swift.yml/badge.svg)](https://github.com/RougeWare/Swift-SerializationTools/actions/workflows/swift.yml) [![Codefactor checked](https://www.codefactor.io/repository/github/rougeware/swift-SerializationTools/badge)](https://www.codefactor.io/repository/github/rougeware/swift-SerializationTools)
+
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRougeWare%2FSwift-SerializationTools%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/RougeWare/Swift-SerializationTools) [![swift package manager 5.3 is supported](https://img.shields.io/badge/swift%20package%20manager-5.3-brightgreen.svg)](https://github.com/RougeWare/Swift-SerializationTools/blob/production/Package.swift) [![Supports macOS, iOS, tvOS, watchOS, Linux, & Windows](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRougeWare%2FSwift-SerializationTools%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/RougeWare/Swift-SerializationTools) 
+[![](https://img.shields.io/github/release-date/rougeware/swift-serializationtools?label=latest%20release)](https://github.com/RougeWare/Swift-SerializationTools/releases/latest)
+
+
+
+# [Swift `SerializationTools`](https://github.com/RougeWare/Swift-SerializationTools) #
 
 Some tools to help y'all serialize stuff
+
+
+
+## JSON conveniences
+
+Swift's JSON encoding & decoding is really good! ... but the API could use a bit of sugar.
+
+This package brings that sweetness!
+
+```swift
+
+// Let's start this example with a simple struct.
+// It's got a little bit going on: there's two fields, each a different type, and one is `Optional`.
+//
+// Its Codable conformance is synthesized from its fields all being Codable.
+// I'm also making it `Equatable` so we can make sure things work properly 
+
+struct NamedCount: Codable, Equatable {
+    let name: String
+    let count: UInt?
+}
+
+
+
+// Now let's make some instances to work with
+
+let bananaCount = NamedCount(name: "Bananas", count: 7)
+let tomorrowEventSecondsCount = NamedCount(name: "Number of Seconds In Tomorrow's Event", count: nil)
+
+
+
+// With those made, what's it look like to serialize them?
+// Well, before this package, you'd have to make a JSONEncoder object, then configure it, then use it, then.... dispose
+// of it I guess? Kinda feels like Objective-C, doesn't it? (Swiftjective-C?)
+//
+// With this package, it's as simple as calling `.jsonString()`!
+// You can even pass configuration to it as parameters! Very Swift-y
+
+// `.jsonString()` creates a UTF-8 JSON string
+let bananaCountJsonString = try bananaCount.jsonString()
+// {"name":"Bananas","count":7}
+
+// `.jsonData()` creates a UTF-8-encoded JSON string as raw `Data`
+let tomorrowEventSecondsCountJsonData = try tomorrowEventSecondsCount.jsonData()
+// Essentially {"name":"Number of Seconds In Tomorrow's Event"}
+
+
+
+// Well that was easy! But what about decoding?
+// That, too, is similarly natural and Swift-y:
+
+let decodedBananaCount = try NamedCount(jsonString: bananaCountJsonString)
+let decodedTomorrowEventSecondsCount = try NamedCount(jsonData: tomorrowEventSecondsCountJsonData)
+
+
+// It's like JSON is a first-class citizen!
+// And of course the decoded values are just the same as before they were encoded:
+
+assert(decodedBananaCount == bananaCount)
+assert(decodedTomorrowEventSecondsCount == tomorrowEventSecondsCount)
+
+
+
+// And of course you can use literals with this too:
+
+let countOfRoadsOneCanWalkDown = try NamedCount(jsonString: """
+{
+    "name": "How many roads can one walk down?",
+    "count": 42
+}
+""")
+```
+
+
+
+## Codable Bridge
+
+`Codable` is the Swift re-imagining of `NSCoding`. I think we all can agree that `Codable` is much better!
+
+But, some things (especially in Apple frameworks) conform to `NSCoding` but not `Codable`! What is one to do?
+
+Well, never fear! A solution[\*](#Codable-bridge-disclaimer) is here!
+
+```swift
+// Probably the most common way that I run into this is with AppKit and UIKit, so let's use those as examples!
+
+struct User: Codable, Equatable {
+    let name: String
+    let avatar: UIImage.CodableBridge?
+    let favoriteColor: UIColor.CodableBridge
+}
+
+
+// I'll only use one instance this time, because I think it's enough to get the point across.
+// Here's Redd. He likes the color red!
+//
+// Here we see the concession to the API user: they have to use `.codable` to create the codable bridge.
+// I recommend making a sugary initializer which just takes the base type, like
+// `init(name: String, avatar: UIImage, favoriteColor: UIColor)`
+
+let redd = User(
+    name: "Redd",
+    avatar: UIImage(named: "Redd-avatar").codable,
+    favoriteColor: UIColor(hue: 0.111, saturation: 0.78, brightness:  0.96, alpha: 1).codable
+)
+
+
+// And I'm sure you expect this, but that struct needs nothing more special to be able to encode &and decode it!
+
+let reddJsonString = try redd.jsonString()
+// Essentially {"name":"Redd","avatar":"<insert Base64 nonsense here>","favoriteColor":"<insert Base64 nonsense here>"}
+
+
+let decodedRedd = try Redd(jsonString: reddJsonString)
+
+
+// And of course the decoded value is just the same as before it was encoded, just like any native `Codable` type:
+
+assert(decodedRedd == redd)
+
+
+// The other caveat is that accessing the base type's methods is a bit indirect as well:
+
+redd.favoriteColor.value.set()
+
+
+// But at least accessing fields is straightforawrd thanks to `@dynamicMemberLookup`:
+
+print(redd.avatar.size)
+```
+
+
+
+> <a id="Codable-bridge-disclaimer"></a>\* Due to the limitations of Swift's approach to reference type initializers, a true `Codable` implementation can't be synthesized on all `NSCoding` types without risking a crash for invalid data. As such, I've decided to make a synthesized subtype of all `NSCoding` types, which can be as easily (en/de)coded. I tried to make this as ergonomic as possible; [let me know if you have any better ideas!](https://github.com/RougeWare/Swift-SerializationTools/issues/new/choose)

--- a/Sources/SerializationTools/CodableBridge.swift
+++ b/Sources/SerializationTools/CodableBridge.swift
@@ -40,6 +40,8 @@ public extension CodableBridge {
 
 // MARK: - Codable
 
+@available(macOS 10.13, *)
+@available(iOS 11, *)
 extension CodableBridge: Encodable {
     public func encode(to encoder: Encoder) throws {
         let nsCoder = NSKeyedArchiver(requiringSecureCoding: true)
@@ -51,6 +53,8 @@ extension CodableBridge: Encodable {
 
 
 
+@available(macOS 10.13, *)
+@available(iOS 11, *)
 extension CodableBridge: Decodable {
     public init(from decoder: Decoder) throws {
         self.init(value: try BaseType(coder: try Self.nsCoder(from: decoder)).unwrappedOrThrow())
@@ -82,6 +86,8 @@ public extension NSCoding {
 
 
 
+@available(macOS 10.13, *)
+@available(iOS 11, *)
 public extension NSCoding where Self: Encodable {
     func encode(to encoder: Encoder) throws {
         try self.codable.encode(to: encoder)
@@ -90,6 +96,8 @@ public extension NSCoding where Self: Encodable {
 
 
 
+@available(macOS 10.13, *)
+@available(iOS 11, *)
 public extension NSCoding where Self: Decodable {
     /// This function allows you to easily decode an `NSCoding` instance
     ///

--- a/Sources/SerializationTools/CodableBridge.swift
+++ b/Sources/SerializationTools/CodableBridge.swift
@@ -1,0 +1,102 @@
+//
+//  CodableBridge.swift
+//  SerializationTools
+//
+//  Created by S🌟System on 2022-12-11.
+//
+
+import Foundation
+
+
+
+/// Allows you to use Swift encoders and decoders to process an `NSCoding` type
+@dynamicMemberLookup
+public struct CodableBridge<BaseType: NSCoding> {
+
+    /// The value to be (en/de)coded
+    public var value: BaseType
+    
+    
+    public init(value: BaseType) {
+        self.value = value
+    }
+}
+
+
+
+public extension CodableBridge {
+    subscript<T>(dynamicMember keyPath: KeyPath<BaseType, T>) -> T {
+        value[keyPath: keyPath]
+    }
+    
+    
+    subscript<T>(dynamicMember keyPath: WritableKeyPath<BaseType, T>) -> T {
+        get { value[keyPath: keyPath] }
+        set { value[keyPath: keyPath] = newValue }
+    }
+}
+
+
+
+// MARK: - Codable
+
+extension CodableBridge: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        let nsCoder = NSKeyedArchiver(requiringSecureCoding: true)
+        value.encode(with: nsCoder)
+        var container = encoder.singleValueContainer()
+        try container.encode(nsCoder.encodedData)
+    }
+}
+
+
+
+extension CodableBridge: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.init(value: try BaseType(coder: try Self.nsCoder(from: decoder)).unwrappedOrThrow())
+    }
+    
+    
+    
+    public static func nsCoder(from decoder: Decoder) throws -> NSCoder {
+        let container = try decoder.singleValueContainer()
+        let decodedData = try container.decode(Data.self)
+        return try NSKeyedUnarchiver(forReadingFrom: decodedData)
+    }
+}
+
+
+
+// MARK: - Sugar on NSCoding
+
+public extension NSCoding {
+    
+    /// A version of this object that can be used with Swift's built-in `Codable` system
+    var codable: CodableBridge {
+        CodableBridge(value: self)
+    }
+    
+    
+    typealias CodableBridge = SerializationTools.CodableBridge<Self>
+}
+
+
+
+public extension NSCoding where Self: Encodable {
+    func encode(to encoder: Encoder) throws {
+        try self.codable.encode(to: encoder)
+    }
+}
+
+
+
+public extension NSCoding where Self: Decodable {
+    /// This function allows you to easily decode an `NSCoding` instance
+    ///
+    /// This was made because `init(from:)` cannot be synthesized due to Swift's compile-time requirements for extensions on reference types
+    ///
+    /// - Parameter decoder: The swift decoder which will be decoding the instance
+    static func decode(from decoder: Decoder) throws -> Self {
+        try Self.init(coder: try CodableBridge.nsCoder(from: decoder)).unwrappedOrThrow()
+    }
+}

--- a/Sources/SerializationTools/JSON conveniences.swift
+++ b/Sources/SerializationTools/JSON conveniences.swift
@@ -1,8 +1,8 @@
 //
 //  JSON conveniences.swift
-//  
+//  SerializationTools
 //
-//  Created by Ben Leggiero on 2020-12-14.
+//  Created by Ky Leggiero on 2020-12-14.
 //
 
 import Foundation
@@ -38,7 +38,7 @@ public extension Encodable {
         encoder.dataEncodingStrategy = dataEncodingStrategy
         encoder.dateEncodingStrategy = dateEncodingStrategy
         encoder.keyEncodingStrategy = keyEncodingStrategy
-        encoder.nonConformingFloatEncodingStrategy = .convertToJavaScriptStyleStrings
+        encoder.nonConformingFloatEncodingStrategy = nonConformingFloatEncodingStrategy
         return try encoder.encode(self)
     }
     

--- a/Tests/SerializationToolsTests/CodableBridge tests.swift
+++ b/Tests/SerializationToolsTests/CodableBridge tests.swift
@@ -1,0 +1,110 @@
+//
+//  CodableBridge tests.swift
+//  SerializationTools
+//
+//  Created by S🌟System on 2022-12-13.
+//
+import XCTest
+import SerializationTools
+
+#if canImport(AppKit)
+    import AppKit
+#endif
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+
+
+class CodableBridgeTests: XCTestCase {
+    
+    #if canImport(AppKit)
+    func testNsColor_rgb() throws {
+        let raw = NSColor(red: 0.7, green: 0.5, blue: 0.2, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try NSColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testNsColor_rgb_dp3() throws {
+        let raw = NSColor.init(displayP3Red: 0.7, green: 0.5, blue: 0.2, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try NSColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testNsColor_hsl() throws {
+        let raw = NSColor(hue: 0.123, saturation: 0.8, brightness: 0.7, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try NSColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testNsColor_white() throws {
+        let raw = NSColor(white: 0.42, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try NSColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testNsColor_system() throws {
+        let raw = NSColor.systemRed
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try NSColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    @available(iOS 13.0, *)
+    func testNsImage_accessingFields() throws {
+        let bridge = try XCTUnwrap(NSImage(systemSymbolName: "testtube.2", accessibilityDescription: "Example text")).codable
+        XCTAssertEqual(bridge.size.width, 16)
+        XCTAssertEqual(bridge.size.height, 16)
+        XCTAssertEqual(bridge.accessibilityDescription, "Example text")
+    }
+    #endif
+    
+    
+    #if canImport(UIKit)
+    func testUiColor_rgb() throws {
+        let raw = UIColor(red: 0.7, green: 0.5, blue: 0.2, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try UIColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testUiColor_rgb_dp3() throws {
+        let raw = UIColor.init(displayP3Red: 0.7, green: 0.5, blue: 0.2, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try UIColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testUiColor_hsl() throws {
+        let raw = UIColor(hue: 0.123, saturation: 0.8, brightness: 0.7, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try UIColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testUiColor_white() throws {
+        let raw = UIColor(white: 0.42, alpha: 1)
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try UIColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    func testUiColor_system() throws {
+        let raw = UIColor.systemRed
+        let jsonString = try raw.codable.jsonString()
+        let decoded = try UIColor.CodableBridge(jsonString: jsonString).value
+        XCTAssertEqual(raw, decoded)
+    }
+    
+    @available(iOS 13.0, *)
+    func testUiImage_accessingFields() throws {
+        let bridge = try XCTUnwrap(UIImage(systemName: "testtube.2")).codable
+        XCTAssertEqual(bridge.size.width, 21)
+        XCTAssertEqual(bridge.size.height, 19.6666, accuracy: 0.0001)
+    }
+    #endif
+}

--- a/Tests/SerializationToolsTests/CodableBridge tests.swift
+++ b/Tests/SerializationToolsTests/CodableBridge tests.swift
@@ -54,11 +54,11 @@ class CodableBridgeTests: XCTestCase {
         XCTAssertEqual(raw, decoded)
     }
     
-    @available(iOS 13.0, *)
+    @available(macOS 11, *)
     func testNsImage_accessingFields() throws {
-        let bridge = try XCTUnwrap(NSImage(systemSymbolName: "testtube.2", accessibilityDescription: "Example text")).codable
-        XCTAssertEqual(bridge.size.width, 16)
-        XCTAssertEqual(bridge.size.height, 16)
+        let bridge = try XCTUnwrap(NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Example text")).codable
+        XCTAssertTrue((15...16).contains(bridge.size.width)) // Old macOS has 16x16, new macOS has 15x17
+        XCTAssertTrue((16...17).contains(bridge.size.height)) // Old macOS has 16x16, new macOS has 15x17
         XCTAssertEqual(bridge.accessibilityDescription, "Example text")
     }
     #endif


### PR DESCRIPTION
This allows `NSCodable` to be bridged to `Codable`!

Also included in this PR:
- Fixed a bug where the `nonConformingFloatEncodingStrategy` argument was ignored in `.jsonData()`
- Actual Readme! 🥳 